### PR TITLE
Fix FilterBy: 'fields' attribute pass to type directly

### DIFF
--- a/freddie/viewsets/dependencies.py
+++ b/freddie/viewsets/dependencies.py
@@ -101,7 +101,7 @@ ResponseFieldsDict = Union[ResponseFields, dict]
 
 
 class FilterBy:
-    fields: Dict[str, ModelField] = {}
+    fields: Dict[str, ModelField]
     PARAM_NAME: str = 'filter_by'
 
     class ModelConfig(BaseConfig):
@@ -112,8 +112,8 @@ class FilterBy:
         if dependency_class is cls:
             return cls  # pragma: no cover
         data_cls = dataclass(dependency_class, config=cls.ModelConfig)
-        cls.fields = data_cls.__pydantic_model__.__fields__
-        return type(cls.__name__, (cls, data_cls), {})
+        fields = data_cls.__pydantic_model__.__fields__
+        return type(cls.__name__, (cls, data_cls), {'fields': fields})
 
     def items(self) -> Iterator[Tuple[str, Any]]:
         for key in self.fields.keys():

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,24 @@
+import pytest
+
+from freddie.viewsets.dependencies import FilterBy
+
+
+@pytest.fixture
+def first_filter():
+    class Filter:
+        slug: str = None
+    return {'slug'}, FilterBy.setup(Filter)
+
+
+@pytest.fixture
+def second_filter():
+    class Filter:
+        id: int = None
+        title: str = None
+    return {'id', 'title'}, FilterBy.setup(Filter)
+
+
+def test_filter_by_attributes_exists(first_filter, second_filter):
+    assert first_filter is not second_filter
+    for expected_fields, filter_class in (first_filter, second_filter):
+        assert expected_fields == set(filter_class.fields)


### PR DESCRIPTION
**Explanation**

'fields' attribute is set in class FilterBy as class attribute
```
class FilterBy:
    fields: Dict[str, ModelField] = {}
```

It is directly overridden in the FilterBy.setup method. As a result, the `fields` attribute always contains the value of the 'fields' of last class passed to the setup method.
```
cls.fields = data_cls.__pydantic_model__.__fields__
return type(cls.__name__, (cls, data_cls), {})
```

I suggest passing the field directly to the `type` constructor.
```
fields = data_cls.__pydantic_model__.__fields__
return type(cls.__name__, (cls, data_cls), {'fields': fields})
```
