### PR TITLE
Add relation_fields to Prefetcher class

### DIFF
--- a/tests/app.py
+++ b/tests/app.py
@@ -7,6 +7,7 @@ from pydantic import BaseSettings, constr
 from freddie import Schema
 from freddie.db import Database, DatabaseManager
 from freddie.db.models import (
+    BooleanField,
     CharField,
     ForeignKeyField,
     JSONField,
@@ -207,15 +208,22 @@ class BaseDBModel(Model):
         database = db
 
 
+class Tag(BaseDBModel):
+    name = CharField(max_length=127, null=False)
+    slug = CharField(max_length=127, null=False, unique=True)
+
+
 class Author(BaseDBModel):
     first_name = CharField(max_length=127, null=False)
     last_name = CharField(max_length=127, null=True)
     nickname = CharField(max_length=127, null=False, unique=True)
+    tags = ManyToManyField(Tag, 'AuthorTags')
 
 
-class Tag(BaseDBModel):
-    name = CharField(max_length=127, null=False)
-    slug = CharField(max_length=127, null=False, unique=True)
+class AuthorTags(BaseDBModel, ThroughModel):
+    tag = ForeignKeyField(Tag, on_delete='CASCADE')
+    author = ForeignKeyField(Author, on_delete='CASCADE')
+    is_notifications_on = BooleanField(default=True)
 
 
 class Post(BaseDBModel):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,24 @@
+from pytest import mark
+
+from freddie.db.queries import Prefetch, prefetch_related
+
+from .app import Author, AuthorTags
+from .factories import AuthorFactory, TagFactory
+
+pytestmark = [mark.asyncio, mark.db]
+
+
+class TestManyToManyModelViewSet:
+    async def test_prefetched_relations(self):
+        author = AuthorFactory.create()
+        watched_tag, ignored_tag = TagFactory.create_batch(2)
+        AuthorTags(author=author, tag=watched_tag, is_notifications_on=True).save()
+        AuthorTags(author=author, tag=ignored_tag, is_notifications_on=False).save()
+
+        prefetcher = Prefetch(
+            field=Author.tags, attr_name='tags', relation_fields=['is_notifications_on']
+        )
+        author = await prefetch_related([author], [prefetcher]).__anext__()
+
+        expected = set(map(lambda x: (x.id, x.is_notifications_on), author.tags))
+        assert expected == {(watched_tag.id, True), (ignored_tag.id, False)}


### PR DESCRIPTION
Default value is set to empty list
If relateion_fields list contains values (relation attribute names) -
these attributes are added to prefetched objects (dicts or objects)